### PR TITLE
Use pip to install instead of just python

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For this solution, you need the following prerequisites:
 Run command below to install python libraries.
 
 ```shell
-python install -r ./requirements.txt
+pip install -r ./requirements.txt
 ```
 
 ## Running the app


### PR DESCRIPTION
*Issue #, if available:*

I think requirements are installed using `pip`, not `python`. But I'm not working with python very often

*Description of changes:*

Update the Readme to install the dependencies using `pip`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
